### PR TITLE
macOS에서 화면이 꺼진상황(Cmt+W)에서 종료(Cmd+Q)를 할 때, 자바스크립트 에러가 나는 부분 수정

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,3 +1,1 @@
 angular.module('atmApp',['ui.grid']);
-
-require('./menu').createMenu();

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,6 @@ echo "finished npm install"
 #$BOWER install
 #echo "finished bower install"
 
-echo "electron-packager . --all --out=${BUILD_DIR} --icon=$ICON"
-$CURRENT_DIR/$ELECTRON_PACKAGER $CURRENT_DIR --all --out=$BUILD_DIR --overwrite
+echo "electron-packager . --all --out=${BUILD_DIR} --icon=$ICON --asar=true --overwrite"
+$CURRENT_DIR/$ELECTRON_PACKAGER $CURRENT_DIR --all --out=$BUILD_DIR --asar=true --overwrite
 echo "finished all packaging"

--- a/main.js
+++ b/main.js
@@ -1,7 +1,6 @@
 const electron = require('electron');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
-
 let mainWindow;
 
 function createWindow () {
@@ -20,6 +19,8 @@ function createWindow () {
 	mainWindow.on('closed', function () {
 		mainWindow = null;
 	});
+
+	require('./menu').createMenu();
 }
 
 app.on('ready', createWindow);

--- a/menu.js
+++ b/menu.js
@@ -1,5 +1,4 @@
-
-var remote = require('electron').remote;
+const electron = require('electron');
 var template = [
 	{
 		label: 'ATM',
@@ -72,13 +71,13 @@ var template = [
 			{
 				label: 'About',
 				click: function(item, focusedWindow) {
-					remote.dialog.showMessageBox({
+					dialog.showMessageBox({
 						type: 'info',
 						buttons: [],
-						title: 'About ' + remote.app.getName(),
+						title: 'About ' + electron.app.getName(),
 						icon: __dirname + '/resource/icon.png',
 						message: 'ATM은 시간 관리용 어플리케이션입니다.\n' +
-								 'Version: ' + remote.app.getVersion()
+								 'Version: ' + app.getVersion()
 					});
 				}
 			}
@@ -89,7 +88,7 @@ var template = [
 exports.createMenu = function() {
 
 	if (process.platform === 'darwin') {
-		const name = remote.app.getName();
+		const name = electron.app.getName();
 		template.unshift({
 			label: name,
 			submenu: [
@@ -120,7 +119,7 @@ exports.createMenu = function() {
 					label: 'Quit',
 					accelerator: 'Command+Q',
 					click: function() {
-						remote.app.quit();
+						electron.app.quit();
 					}
 				}
 			]
@@ -136,7 +135,6 @@ exports.createMenu = function() {
 		);
 	}
 
-	var Menu = remote.Menu;
-	const menu = Menu.buildFromTemplate(template);
-	Menu.setApplicationMenu(menu);
+	const menu = electron.Menu.buildFromTemplate(template);
+	electron.Menu.setApplicationMenu(menu);
 };


### PR DESCRIPTION
1. macOS에서 화면이 꺼진상황(Cmt+W)에서 종료(Cmd+Q)를 할 때, 자바스크립트 에러가 나는 부분 수정
2. build 할 때, *.asar로 압축하여 빌드하도록 로직 추가
- 1번 항목 원인
  - 기존에 상단의 메뉴를 Renderer프로세스에서 만들고 있었음. (app/app.js 내부에서)
  - 화면이 꺼지게 되면 랜더러 프로세스의 remote 객체도 소멸되어 undefined됨
  - undefined 된 remote객체를 통해 종료시키려니 발생하는 문제 i.e) remote.app.quit()
- 수정사항
  - menu.js, 메뉴를 생성하는 로직을 main프로세스로 이관
